### PR TITLE
Closes #19: Bubble cannot start on android 14

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,9 +4,17 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+
 
     <application>
-        <service android:name=".src.BubbleService" />
+       <service
+        android:name=".src.BubbleService"
+        android:foregroundServiceType="specialUse">
+        <property 
+        android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE" 
+        android:value="By using a foreground service, we can ensure that the bubble remains visible and accessible to the user even when they switch to other apps."/>  <!-- optional -->
+     </service>
     </application>
 
 </manifest>

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
This change adds a type declaration in the Android manifest, which is required for apps targeting Android 14.
If an app that targets Android 14 doesn't define types for a given service in the manifest, then the system will raise `MissingForegroundServiceTypeException` upon calling `startForeground()` for that service.
Read more here: https://developer.android.com/about/versions/14/changes/fgs-types-required

Related Issues:
- Closes #19
- Fixes #14 (already closed without being resolved)